### PR TITLE
APIドキュメント用のエンドポイントを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ $ make up
 
 - バックエンド
   - http://localhost:8000
+- APIドキュメント
+  - http://localhost:8000/api/schema/swagger-ui/
 - フロントエンド
   - http://localhost:3000
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "djoser",
     "django_filters",
+    "drf_spectacular",
     # Django
     "django.contrib.admin",
     "django.contrib.auth",
@@ -148,6 +149,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
 # ヘッダータイプの指定,アクセストークンの有効期限を30分に設定,リフレッシュトークンの有効期限を7日に設定

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -16,8 +16,11 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path("admin/", admin.site.urls),
     path("accounts/", include("accounts.urls")),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ django-environ
 black
 flake8
 isort
+drf-spectacular


### PR DESCRIPTION
サーバーを起動して
http://localhost:8000/api/schema/swagger-ui/
にアクセスすると見れます。
以下のように実装したAPIの情報が書かれています。
![Swagger - Google Chrome 2023_06_14 (水) 22_22_40](https://github.com/kenketsu/leading-twitter-clone_team_b/assets/107803562/699c1291-492a-49fe-99e4-af28e1b515b5)
